### PR TITLE
Add mention of Synapse Team edition to standard edition's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Synapse Module Cookiecutter Template
+# Synapse Module Cookiecutter Template (Standard Edition)
 
 This is a [Cookiecutter] template for creating new [Synapse] modules.
+
+**⚠ This is the standard edition of the template. Synapse team members should use
+the [Synapse team edition](https://github.com/matrix-org/synapse-module-cookiecutter-template/tree/synapse_team).**
 
 [Cookiecutter]: https://pypi.org/project/cookiecutter/
 [Synapse]: https://github.com/matrix-org/synapse


### PR DESCRIPTION
Thought it might be sensible to have this there so that Synapse team members know about it and don't accidentally use the default one.