### PR TITLE
Make Synapse Core the CODEOWNERS of templated repositories

### DIFF
--- a/{{ cookiecutter.directory_name }}/.github/CODEOWNERS
+++ b/{{ cookiecutter.directory_name }}/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request reviews from the synapse-core team when a pull request comes in.
+* @matrix-org/synapse-core


### PR DESCRIPTION
(This is for the Synapse Team template only)