### PR TITLE
Make Synapse Core the CODEOWNERS of templated repositories if a `synapse_team` variant is in use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ What you get:
     * strict by default (configurable in `mypy.ini`)
 * unit testing using `trial` (invokable with `tox`, checked in CI)
 * *Specific to the 'Synapse Team' variant:*
-  * `CODEOWNERS` for automatic review requests for the Synapse Core Team when a
-    pull request is opened
+  * `CODEOWNERS` for automatic review requests for the 'Synapse Core' team on
+    GitHub when a pull request is opened
 
 Please refer to [the Synapse 'Writing a module' documentation][synapse_writemodule]
 for descriptions and examples (at the bottom of most pages) of using the Synapse

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ What you get:
     * strict by default (configurable in `mypy.ini`)
 * unit testing using `trial` (invokable with `tox`, checked in CI)
 * *Specific to the 'Synapse Team' variant:*
-  * `CODEOWNERS` for review requests on Synapse Core Team
+  * `CODEOWNERS` for automatic review requests for the Synapse Core Team when a
+    pull request is opened
 
 Please refer to [the Synapse 'Writing a module' documentation][synapse_writemodule]
 for descriptions and examples (at the bottom of most pages) of using the Synapse

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ You will then be asked a series of questions to populate your project:
    the CI configuration and suggested release instructions mention it.
    This is commonly `main`, `master`, `trunk`, `default` or `develop`.
 7. `variant`: Choose whether or not to include the Synapse Team-specific
-   customisations; use `standard` if you are a community member or `synapse_team`
-   if the Synapse Team is going to be maintaining this module.
+   customisations; pick `synapse_team` if the module will be maintained
+   by the Synapse Team. Otherwise, pick `standard`.
 
 
 If all goes well, you should now have a project starter!

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ What you get:
     Synapse 1.46 and later)
     * strict by default (configurable in `mypy.ini`)
 * unit testing using `trial` (invokable with `tox`, checked in CI)
+* *Specific to the 'Synapse Team' variant:*
+  * `CODEOWNERS` for review requests on Synapse Core Team
 
 Please refer to [the Synapse 'Writing a module' documentation][synapse_writemodule]
 for descriptions and examples (at the bottom of most pages) of using the Synapse
@@ -61,6 +63,10 @@ You will then be asked a series of questions to populate your project:
    Although this template does not initialise a Git repository automatically,
    the CI configuration and suggested release instructions mention it.
    This is commonly `main`, `master`, `trunk`, `default` or `develop`.
+7. `variant`: Choose whether or not to include the Synapse Team-specific
+   customisations; use `standard` if you are a community member or `synapse_team`
+   if the Synapse Team is going to be maintaining this module.
+
 
 If all goes well, you should now have a project starter!
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ What you get:
     * strict by default (configurable in `mypy.ini`)
 * unit testing using `trial` (invokable with `tox`, checked in CI)
 * *Specific to the 'Synapse Team' variant:*
-  * `CODEOWNERS` for automatic review requests for the 'Synapse Core' team on
+  * `CODEOWNERS` for automatic review requests for the `synapse-core` team on
     GitHub when a pull request is opened
 
 Please refer to [the Synapse 'Writing a module' documentation][synapse_writemodule]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You will then be asked a series of questions to populate your project:
    Although this template does not initialise a Git repository automatically,
    the CI configuration and suggested release instructions mention it.
    This is commonly `main`, `master`, `trunk`, `default` or `develop`.
-7. `variant`: Choose whether or not to include the Synapse Team-specific
+7. `variant`: Choose whether or not to include the 'Synapse Team'-specific
    customisations; pick `synapse_team` if the module will be maintained
    by the Synapse Team. Otherwise, pick `standard`.
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,6 @@
   "package_description": "This module adds super florbs to Synapse",
   "package_name": "synapse_my_module",
   "module_class_name": "MyModule",
-  "main_git_branch": "main"
+  "main_git_branch": "main",
+  "variant": ["standard", "synapse_team"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,9 +2,13 @@
 # (mainly with respect to Windows)
 import subprocess
 import sys
+import os
 
 # this will be substituted by cookiecutter.
 main_branch_name = '{{ cookiecutter.main_git_branch }}'
+
+# we use this to remove optional files
+variant_name = '{{ cookiecutter.variant }}'
 
 try:
     subprocess.run(
@@ -16,3 +20,14 @@ except subprocess.CalledProcessError:
         f"Please do so with branch name: '{main_branch_name}'",
         file=sys.stderr
     )
+
+# Remove files that don't correspond to this variant
+files_to_remove = []
+
+if variant_name != 'synapse_team':
+    files_to_remove = [
+        ".github/CODEOWNERS",
+    ]
+
+for file_to_remove in files_to_remove:
+    os.unlink(file_to_remove)

--- a/{{ cookiecutter.directory_name }}/.github/CODEOWNERS
+++ b/{{ cookiecutter.directory_name }}/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+{# This file will only be included if the 'Synapse Team' variant is used. #}
+# Automatically request reviews from the synapse-core team when a pull request comes in.
+* @matrix-org/synapse-core


### PR DESCRIPTION
This adds a `standard` and `synapse_team` variant (presented as a menu).

The Synapse Team variant will include customisations specific to modules maintained by us.