### PR TITLE
Prevent linters from disagreeing on line lengths

### DIFF
--- a/{{ cookiecutter.directory_name }}/setup.cfg
+++ b/{{ cookiecutter.directory_name }}/setup.cfg
@@ -26,13 +26,11 @@ dev =
 
 
 [flake8]
-# line length defaulted to by black
-max-line-length = 88
-
 # see https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # for error codes. The ones we ignore are:
 #  W503: line break before binary operator
 #  W504: line break after binary operator
 #  E203: whitespace before ':' (which is contrary to pep8?)
+#  E501: Line too long (black enforces this for us)
 # (this is a subset of those ignored in Synapse)
-ignore=W503,W504,E203
+ignore=W503,W504,E203,E501


### PR DESCRIPTION
I recently had the awkward situation where, for this line: https://github.com/matrix-org/synapse-auto-accept-invite/blob/babolivier/first_cut/tests/test_example.py#L74

flake8 argued the line was too long (> 88 chars), but when I broke it down (by moving the closing quotes to the next line) black then argued that the right version of that line was with the quotes on the same line as the text (as done originally):

```
$ tox -e check_codestyle
check_codestyle inst-nodeps: /home/babolivier/Documents/matrix/synapse-auto-accept-invite/.tox/.tmp/package/1/synapse_auto_accept_invite-1.0.0.tar.gz
check_codestyle installed: aiounittest==1.4.1,attrs==21.2.0,Automat==20.2.0,backports.entry-points-selectable==1.1.1,bcrypt==3.2.0,black==21.9b0,bleach==4.1.0,canonicaljson==1.5.0,certifi==2021.10.8,cffi==1.15.0,charset-normalizer==2.0.7,click==8.0.3,constantly==15.1.0,cryptography==35.0.0,distlib==0.3.3,filelock==3.3.2,flake8==4.0.1,frozendict==2.0.7,hyperlink==21.0.0,idna==3.3,ijson==3.1.4,importlib-metadata==4.8.2,incremental==21.3.0,isort==5.9.3,Jinja2==3.0.3,jsonschema==4.2.1,MarkupSafe==2.0.1,matrix-synapse==1.46.0,mccabe==0.6.1,msgpack==1.0.2,mypy==0.910,mypy-extensions==0.4.3,netaddr==0.8.0,packaging==21.2,pathspec==0.9.0,phonenumbers==8.12.36,Pillow==8.4.0,platformdirs==2.4.0,pluggy==1.0.0,prometheus-client==0.12.0,py==1.11.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycodestyle==2.8.0,pycparser==2.21,pyflakes==2.4.0,pymacaroons==0.13.0,PyNaCl==1.4.0,pyOpenSSL==21.0.0,pyparsing==2.4.7,pyrsistent==0.18.0,PyYAML==6.0,regex==2021.11.10,requests==2.26.0,service-identity==21.1.0,signedjson==1.1.1,simplejson==3.17.5,six==1.16.0,sortedcontainers==2.4.0,synapse-auto-accept-invite @ file:///home/babolivier/Documents/matrix/synapse-auto-accept-invite/.tox/.tmp/package/1/synapse_auto_accept_invite-1.0.0.tar.gz,toml==0.10.2,tomli==1.2.2,tox==3.24.4,treq==21.5.0,Twisted==21.7.0,typing-extensions==3.10.0.2,unpaddedbase64==2.1.0,urllib3==1.26.7,virtualenv==20.10.0,webencodings==0.5.1,wrapt==1.13.3,zipp==3.6.0,zope.interface==5.4.0
check_codestyle run-test-pre: PYTHONHASHSEED='1146757542'
check_codestyle run-test: commands[0] | flake8 synapse_auto_accept_invite tests
tests/test_example.py:74:89: E501 line too long (89 > 88 characters)
ERROR: InvocationError for command /home/babolivier/Documents/matrix/synapse-auto-accept-invite/.tox/check_codestyle/bin/flake8 synapse_auto_accept_invite tests (exited with code 1)
___________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________
ERROR:   check_codestyle: commands failed



# changing the file happens



$ tox -e check_codestyle
check_codestyle create: /home/babolivier/Documents/matrix/synapse-auto-accept-invite/.tox/check_codestyle
check_codestyle inst: /home/babolivier/Documents/matrix/synapse-auto-accept-invite/.tox/.tmp/package/1/synapse_auto_accept_invite-1.0.0.tar.gz
check_codestyle installed: aiounittest==1.4.1,attrs==21.2.0,Automat==20.2.0,backports.entry-points-selectable==1.1.1,bcrypt==3.2.0,black==21.9b0,bleach==4.1.0,canonicaljson==1.5.0,certifi==2021.10.8,cffi==1.15.0,charset-normalizer==2.0.7,click==8.0.3,constantly==15.1.0,cryptography==35.0.0,distlib==0.3.3,filelock==3.3.2,flake8==4.0.1,frozendict==2.0.7,hyperlink==21.0.0,idna==3.3,ijson==3.1.4,importlib-metadata==4.8.2,incremental==21.3.0,isort==5.9.3,Jinja2==3.0.3,jsonschema==4.2.1,MarkupSafe==2.0.1,matrix-synapse==1.46.0,mccabe==0.6.1,msgpack==1.0.2,mypy==0.910,mypy-extensions==0.4.3,netaddr==0.8.0,packaging==21.2,pathspec==0.9.0,phonenumbers==8.12.36,Pillow==8.4.0,platformdirs==2.4.0,pluggy==1.0.0,prometheus-client==0.12.0,py==1.11.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycodestyle==2.8.0,pycparser==2.21,pyflakes==2.4.0,pymacaroons==0.13.0,PyNaCl==1.4.0,pyOpenSSL==21.0.0,pyparsing==2.4.7,pyrsistent==0.18.0,PyYAML==6.0,regex==2021.11.10,requests==2.26.0,service-identity==21.1.0,signedjson==1.1.1,simplejson==3.17.5,six==1.16.0,sortedcontainers==2.4.0,synapse-auto-accept-invite @ file:///home/babolivier/Documents/matrix/synapse-auto-accept-invite/.tox/.tmp/package/1/synapse_auto_accept_invite-1.0.0.tar.gz,toml==0.10.2,tomli==1.2.2,tox==3.24.4,treq==21.5.0,Twisted==21.7.0,typing-extensions==3.10.0.2,unpaddedbase64==2.1.0,urllib3==1.26.7,virtualenv==20.10.0,webencodings==0.5.1,wrapt==1.13.3,zipp==3.6.0,zope.interface==5.4.0
check_codestyle run-test-pre: PYTHONHASHSEED='75521985'
check_codestyle run-test: commands[0] | flake8 synapse_auto_accept_invite tests
check_codestyle run-test: commands[1] | black --check --diff synapse_auto_accept_invite tests
--- tests/test_example.py	2021-11-10 17:51:08.222143 +0000
+++ tests/test_example.py	2021-11-11 09:59:25.547150 +0000
@@ -69,12 +69,11 @@
         await self.module.on_new_event(event=invite)
 
         self.assertEqual(self.module._api.update_room_membership.call_count, 0)
 
     async def test_not_invite(self) -> None:
-        """Tests that receiving a membership update that's not an invite does nothing.
-        """
+        """Tests that receiving a membership update that's not an invite does nothing."""
         invite = MockEvent(
             sender=self.user_id,
             state_key=self.user_id,
             type="m.room.member",
             content={"membership": "join"},
would reformat tests/test_example.py
Oh no! 💥 💔 💥
1 file would be reformatted, 2 files would be left unchanged.
ERROR: InvocationError for command /home/babolivier/Documents/matrix/synapse-auto-accept-invite/.tox/check_codestyle/bin/black --check --diff synapse_auto_accept_invite tests (exited with code 1)
___________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________
ERROR:   check_codestyle: commands failed
```

To avoid having to deal with 2 competing definition of a good line length, this PR disables the line length check in flake8, which is what we do in Synapse: https://github.com/matrix-org/synapse/blob/6ce19b94e84eb6ad83ef303f88d8bd59a3d414e6/setup.cfg#L13-L21