### PR TITLE
Improvements around releasing modules on PyPI

### DIFF
--- a/{{ cookiecutter.directory_name }}/.gitignore
+++ b/{{ cookiecutter.directory_name }}/.gitignore
@@ -5,3 +5,4 @@
 /.tox
 _trial_temp
 __pycache__
+dist

--- a/{{ cookiecutter.directory_name }}/.gitignore
+++ b/{{ cookiecutter.directory_name }}/.gitignore
@@ -5,4 +5,4 @@
 /.tox
 _trial_temp
 __pycache__
-dist
+/dist

--- a/{{ cookiecutter.directory_name }}/README.md
+++ b/{{ cookiecutter.directory_name }}/README.md
@@ -79,4 +79,8 @@ Synapse developers (assuming a Unix-like shell):
     Create a *release*, based on the tag you just pushed, on GitHub or GitLab.
 
  8. If applicable:
-    Create a source distribution and upload it to PyPI.
+    Create a source distribution and upload it to PyPI:
+    ```shell
+    python -m build
+    twine upload dist/{{ cookiecutter.package_name }}-$version*
+    ```

--- a/{{ cookiecutter.directory_name }}/setup.cfg
+++ b/{{ cookiecutter.directory_name }}/setup.cfg
@@ -1,6 +1,8 @@
 [metadata]
 name = {{ cookiecutter.package_name }}
 description = "{{ cookiecutter.package_description }}"
+long_description = file: README.md
+long_description_content_type = text/markdown
 version = 0.0.0
 
 


### PR DESCRIPTION
* Include the project's readme in the package's long description
* Document the required incantations to build and publish on pypi
* Ignore built artifacts in git