### PR TITLE
Support git versions before 2.28

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -11,9 +11,8 @@ main_branch_name = '{{ cookiecutter.main_git_branch }}'
 variant_name = '{{ cookiecutter.variant }}'
 
 try:
-    subprocess.run(
-        ['git', 'init', '--initial-branch', main_branch_name]
-    )
+    subprocess.run(['git', 'init'])
+    subprocess.run(['git', 'checkout', '-b', main_branch_name])
 except subprocess.CalledProcessError:
     print(
         "Unable to initialise git repository! "


### PR DESCRIPTION
`git init --initial-branch` requires git >= 2.28. Unfortunately, the
latest LTS release of Ubuntu only has git 2.25 available by default.

Fixes #15.