### PR TITLE
Use unittest for tests instead of trial

### DIFF
--- a/{{ cookiecutter.directory_name }}/setup.cfg
+++ b/{{ cookiecutter.directory_name }}/setup.cfg
@@ -19,7 +19,6 @@ dev =
   # for tests
   matrix-synapse
   tox
-  twisted
   aiounittest
   # for type checking
   mypy == 0.910

--- a/{{ cookiecutter.directory_name }}/tox.ini
+++ b/{{ cookiecutter.directory_name }}/tox.ini
@@ -5,20 +5,10 @@ envlist = py, check_codestyle, check_types
 isolated_build = true
 
 [testenv:py]
-
-# As of twisted 16.4, trial tries to import the tests as a package (previously
-# it loaded the files explicitly), which means they need to be on the
-# pythonpath. Our sdist doesn't include the 'tests' package, so normally it
-# doesn't work within the tox virtualenv.
-#
-# As a workaround, we tell tox to do install with 'pip -e', which just
-# creates a symlink to the project directory instead of unpacking the sdist.
-usedevelop=true
-
 extras = dev
 
 commands =
-  python -m twisted.trial tests
+  python -m unittest discover
 
 [testenv:check_codestyle]
 


### PR DESCRIPTION
When running `tox -e py` locally to run tests I realised it complained that it couldn't find `setup.py` (which makes sense since we switched to `setup.cfg`) unless I ran `rm -r .tox/` before _every_ run. When digging, I realised it's because we run tox with `usedevelop=true`, which, according to [docs](https://tox.wiki/en/latest/config.html#conf-usedevelop), relies on `setup.py` to work.

We only do this because we want to run `trial` in CI, but imho the burden of having to recreate the tox environment for every run outweighs the advantages of using `trial` instead of e.g. Python's own `unittest` module. So my suggestion is that we stop using `trial` in favour of `unittest`.