### PR TITLE
Remove quotation marks around description and actually include the code

### DIFF
--- a/{{ cookiecutter.directory_name }}/setup.cfg
+++ b/{{ cookiecutter.directory_name }}/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = {{ cookiecutter.package_name }}
-description = "{{ cookiecutter.package_description }}"
+description = {{ cookiecutter.package_description }}
 long_description = file: README.md
 long_description_content_type = text/markdown
 version = 0.0.0
@@ -9,6 +9,8 @@ classifiers =
   License :: OSI Approved :: Apache Software License
 
 [options]
+packages =
+  {{ cookiecutter.package_name }}
 python_requires = >= 3.7
 install_requires =
   attrs


### PR DESCRIPTION
Quotation marks in the description get rendered verbatim.
Specify `packages`, otherwise we will build empty packages.