### PR TITLE
Declare type checking support by including `py.typed`, as per PEP 561

### DIFF
--- a/{{ cookiecutter.directory_name }}/setup.cfg
+++ b/{{ cookiecutter.directory_name }}/setup.cfg
@@ -8,12 +8,17 @@ version = 0.0.0
 classifiers =
   License :: OSI Approved :: Apache Software License
 
+
 [options]
 packages =
   {{ cookiecutter.package_name }}
 python_requires = >= 3.7
 install_requires =
   attrs
+
+
+[options.package_data]
+{{ cookiecutter.package_name }} = py.typed
 
 
 [options.extras_require]


### PR DESCRIPTION
Otherwise mypy won't pick up the type hints in downstream packages, not
that we expect any.