### PR TITLE
Copy GHA config for releasing to PyPI from s3 storage provider

### DIFF
--- a/{{ cookiecutter.directory_name }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.directory_name }}/.github/workflows/ci.yml
@@ -43,3 +43,17 @@ jobs:
       - run: python -m pip install tox
       - run: tox -e py
 
+  check-build:  
+    name: Build and check Python package
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.x"
+      - name: "Install packaging tools"
+        run: "python -m pip install --upgrade build twine"
+      - name: "Build dist package"
+        run: "python -m build"
+      - name: "Run twine checks"
+        run: "python -m twine check dist/*"

--- a/{{ cookiecutter.directory_name }}/.github/workflows/release.yml
+++ b/{{ cookiecutter.directory_name }}/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# See also https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ 
+
 name: "Build and upload to PyPI"
 on:
   release:
@@ -11,7 +13,7 @@ jobs:
 
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.6"
+          python-version: "3.x"
 
       - name: "Install packaging tools"
         run: "python -m pip install --upgrade build twine"

--- a/{{ cookiecutter.directory_name }}/.github/workflows/release.yml
+++ b/{{ cookiecutter.directory_name }}/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: "Build and upload to PyPI"
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.6"
+
+      - name: "Install packaging tools"
+        run: "python -m pip install --upgrade build twine"
+
+      - name: "Build dist package"
+        run: "python -m build"
+
+      - name: "Upload to PyPI"
+        run: "python -m twine upload dist/*"
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: "${{ secrets.PYPI_API_TOKEN }}"


### PR DESCRIPTION
https://github.com/matrix-org/synapse-s3-storage-provider/pull/69 and https://github.com/matrix-org/synapse-s3-storage-provider/pull/70 but for the generic template.

This will have the following effects:
- modules created with the template will have a CI step checking they can be built into a distribution package
- publishing a release will attempt to publish to PYPI. This requires the repository to have a `PYPI_API_TOKEN` secret set and will fail otherwise.