### PR TITLE
Improvements to the module template

### DIFF
--- a/{{ cookiecutter.directory_name }}/setup.cfg
+++ b/{{ cookiecutter.directory_name }}/setup.cfg
@@ -29,9 +29,9 @@ dev =
   twisted
   aiounittest
   # for type checking
-  mypy == 0.910
+  mypy == 0.931
   # for linting
-  black == 21.9b0
+  black == 22.3.0
   flake8 == 4.0.1
   isort == 5.9.3
 

--- a/{{ cookiecutter.directory_name }}/tests/__init__.py
+++ b/{{ cookiecutter.directory_name }}/tests/__init__.py
@@ -1,7 +1,23 @@
+{% if cookiecutter.variant == "synapse_team" -%}
+# Copyright {% now 'utc', '%Y' %} The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{% endif -%}
 from typing import Any, Dict, Optional
 
 import attr
-from mock import Mock
+from unittest.mock import Mock
 from synapse.module_api import ModuleApi
 
 from {{ cookiecutter.package_name }} import {{ cookiecutter.module_class_name }}
@@ -10,6 +26,7 @@ from {{ cookiecutter.package_name }} import {{ cookiecutter.module_class_name }}
 @attr.s(auto_attribs=True)
 class MockEvent:
     """Mocks an event. Only exposes properties the module uses."""
+
     sender: str
     type: str
     content: Dict[str, Any]

--- a/{{ cookiecutter.directory_name }}/tests/__init__.py
+++ b/{{ cookiecutter.directory_name }}/tests/__init__.py
@@ -14,13 +14,28 @@
 # limitations under the License.
 
 {% endif -%}
-from typing import Any, Dict, Optional
+from asyncio import Future
+from typing import Any, Awaitable, Dict, Optional, TypeVar
 
 import attr
 from unittest.mock import Mock
 from synapse.module_api import ModuleApi
 
 from {{ cookiecutter.package_name }} import {{ cookiecutter.module_class_name }}
+
+TV = TypeVar("TV")
+
+
+def make_awaitable(result: TV) -> Awaitable[TV]:
+    """
+    Makes an awaitable, suitable for mocking an `async` function.
+    This uses Futures as they can be awaited multiple times so can be returned
+    to multiple callers.
+    This function has been copied directly from Synapse's tests code.
+    """
+    future = Future()  # type: ignore
+    future.set_result(result)
+    return future
 
 
 @attr.s(auto_attribs=True)

--- a/{{ cookiecutter.directory_name }}/tests/test_example.py
+++ b/{{ cookiecutter.directory_name }}/tests/test_example.py
@@ -18,5 +18,5 @@ import aiounittest
 
 
 class ExampleTest(aiounittest.AsyncTestCase):
-    def test_example(self) -> None:
+    async def test_example(self) -> None:
         self.assertEqual(1, 2 - 1)


### PR DESCRIPTION
Fixing a bunch of pain points I've been feeling lately when using the template:

* Update linter versions to match Synapse's CI
* Apply changes requested by Black
* Add a header to `tests/__init__.py`
* Import `Mock` from `unittest.mock`
* Add a `make_awaitable` test util (lifted from Synapse's tests code) since I end up reusing it quite often in modules
* Make the example test async