### PR TITLE
Re-order imports to fix mypy in generated modules

### DIFF
--- a/{{ cookiecutter.directory_name }}/tests/__init__.py
+++ b/{{ cookiecutter.directory_name }}/tests/__init__.py
@@ -16,9 +16,9 @@
 {% endif -%}
 from asyncio import Future
 from typing import Any, Awaitable, Dict, Optional, TypeVar
+from unittest.mock import Mock
 
 import attr
-from unittest.mock import Mock
 from synapse.module_api import ModuleApi
 
 from {{ cookiecutter.package_name }} import {{ cookiecutter.module_class_name }}


### PR DESCRIPTION
After generating a module using this template, I had an isort linting failure: https://github.com/matrix-org/synapse-custom-room-presets/runs/6623219584?check_suite_focus=true#step:5:26

This PR fixes the linting issue by reordering an import.