### PR TITLE
Use ruff instead of flake8

### DIFF
--- a/{{ cookiecutter.directory_name }}/pyproject.toml
+++ b/{{ cookiecutter.directory_name }}/pyproject.toml
@@ -29,8 +29,7 @@ dev = [
   "mypy == 1.6.1",
   # for linting
   "black == 23.10.0",
-  "flake8 == 6.1.0",
-  "isort == 5.12.0",
+  "ruff == 0.1.1",
 ]
 
 [build-system]
@@ -49,12 +48,45 @@ build-backend = "setuptools.build_meta"
 
 {%- endif%}
 
-[tool.isort]
-profile = "black"
-known_first_party = [
-    "{{ cookiecutter.package_name }}",
-    "tests"
-]
-
 [tool.mypy]
 strict = true
+
+[tool.ruff]
+line-length = 88
+
+# See https://docs.astral.sh/ruff/rules/#error-e
+# for error codes. The ones we ignore are:
+#  E501: Line too long (black enforces this for us)
+#  E731: do not assign a lambda expression, use a def
+#
+# flake8-bugbear compatible checks. Its error codes are described at
+# https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+#  B023: Functions defined inside a loop must not use variables redefined in the loop
+ignore = [
+    "B023",
+    "E501",
+    "E731",
+]
+select = [
+    # pycodestyle
+    "E",
+    "W",
+    # pyflakes
+    "F",
+    # flake8-bugbear
+    "B0",
+    # flake8-comprehensions
+    "C4",
+    # flake8-2020
+    "YTT",
+    # flake8-slots
+    "SLOT",
+    # flake8-debugger
+    "T10",
+    # flake8-pie
+    "PIE",
+    # flake8-executable
+    "EXE",
+    # isort
+    "I",
+]

--- a/{{ cookiecutter.directory_name }}/scripts-dev/lint.sh
+++ b/{{ cookiecutter.directory_name }}/scripts-dev/lint.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Runs linting scripts and type checking
-# isort - sorts import statements
 # black - opinionated code formatter
-# flake8 - lints and finds mistakes
+# ruff - lints, finds mistakes, and sorts import statements
 # mypy - checks type annotations
 
 set -e
@@ -15,7 +14,6 @@ files=(
 # Print out the commands being run
 set -x
 
-isort "${files[@]}"
-python3 -m black "${files[@]}"
-flake8 "${files[@]}"
+black "${files[@]}"
+ruff --fix "${files[@]}"
 mypy "${files[@]}"

--- a/{{ cookiecutter.directory_name }}/tox.ini
+++ b/{{ cookiecutter.directory_name }}/tox.ini
@@ -17,16 +17,7 @@ extras = dev
 
 commands =
   black --check --diff {{ cookiecutter.package_name }} tests
-  isort --check-only --diff {{ cookiecutter.package_name }} tests
-  flake8 {{ cookiecutter.package_name }} tests
-
-[testenv:fix_codestyle]
-
-extras = dev
-
-commands =
-  black {{ cookiecutter.package_name }} tests
-  isort {{ cookiecutter.package_name }} tests
+  ruff --diff {{ cookiecutter.package_name }} tests
 
 [testenv:check_types]
 
@@ -34,13 +25,3 @@ extras = dev
 
 commands =
   mypy {{ cookiecutter.package_name }} tests
-
-[flake8]
-# see https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
-# for error codes. The ones we ignore are:
-#  W503: line break before binary operator
-#  W504: line break after binary operator
-#  E203: whitespace before ':' (which is contrary to pep8?)
-#  E501: Line too long (black enforces this for us)
-# (this is a subset of those ignored in Synapse)
-extend-ignore = W503,W504,E203,E501


### PR DESCRIPTION
Also:
- remove isort and enable isort rules for ruff.
- remove newly introduced `fix_checkstyle` tox target since there is a `lint.sh` script for that

Signed-off-by: Mathieu Velten [matmaul@gmail.com](mailto:matmaul@gmail.com)